### PR TITLE
Add a CI Build using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,14 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
-    - name: Install dependencies
-      run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build -c Release
+    - name: Pack
+      run: dotnet pack -c Release
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: bin
+        path: IO.Eventuate.Tram/bin
     - name: Unit Test
-      run: dotnet test --no-restore --verbosity normal IO.Eventuate.Tram.UnitTests/ 
+      run: dotnet test -c Release --no-build --verbosity normal IO.Eventuate.Tram.UnitTests/ 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ master, build ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
+        source-url: https://nuget.pkg.github.com/ge-digital-firestorm/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Build
       run: ./build.sh
     - name: Upload bin folder
@@ -42,3 +45,5 @@ jobs:
       with:
         name: integration-test-results
         path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults
+    - name: Publish nuget package
+      run: dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,13 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 3.1.201
 
     - name: Build
       run: ./build.sh
       env:
         PACKAGE_ID: ${{secrets.PACKAGE_ID}}
+        
     - name: Upload bin folder
       uses: actions/upload-artifact@v1
       with:
@@ -31,6 +32,7 @@ jobs:
 
     - name: Unit Tests
       run: dotnet test -c Release --no-build --verbosity normal --logger trx IO.Eventuate.Tram.UnitTests/
+      
     - name: Upload unit test results
       uses: actions/upload-artifact@v1
       if: always()
@@ -43,6 +45,7 @@ jobs:
       working-directory: ./IO.Eventuate.Tram.IntegrationTests
       env:
         CDC_SERVICE_DOCKER_VERSION: 0.21.3.RELEASE
+        
     - name: Upload integration test results
       uses: actions/upload-artifact@v1
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ master ]
 
+# If the build was triggered due to a tag that starts with 'v', consider it a tagged release
+env:
+  IS_TAGGED_RELEASE: ${{startsWith(github.ref, 'refs/tags/v')}}
+
 jobs:
   build:
 
@@ -43,10 +47,10 @@ jobs:
         path: IO.Eventuate.Tram.UnitTests/TestResults
  
     - name: Integration Tests
-      run: ./test.sh
       working-directory: ./IO.Eventuate.Tram.IntegrationTests
       env:
         CDC_SERVICE_DOCKER_VERSION: 0.21.3.RELEASE
+      run: ./test.sh
         
     - name: Upload integration test results
       uses: actions/upload-artifact@v1
@@ -58,4 +62,9 @@ jobs:
     - name: Publish nuget package
       # Don't publish nuget packages for builds triggered by pull requests (pull requests from forks won't have access to secrets anyway)
       if: github.event_name != 'pull_request'
-      run: dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg --source ${{secrets.NUGET_PUBLISH_URL}} --api-key ${{secrets.NUGET_API_KEY}}
+      env:
+        SNAPSHOT_NUGET_PUBLISH_URL: ${{secrets.SNAPSHOT_NUGET_PUBLISH_URL}}
+        SNAPSHOT_NUGET_API_KEY: ${{secrets.SNAPSHOT_NUGET_API_KEY}}
+        NUGET_PUBLISH_URL: ${{secrets.NUGET_PUBLISH_URL}}
+        NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
+      run: ./publish-artifacts.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,7 @@ jobs:
       with:
         name: bin
         path: IO.Eventuate.Tram/bin
-    - name: Unit Test
-      run: dotnet test -c Release --no-build --verbosity normal IO.Eventuate.Tram.UnitTests/ 
+    - name: Unit Tests
+      run: dotnet test -c Release --no-build --verbosity normal IO.Eventuate.Tram.UnitTests/
+    - name: Integration Tests
+      run: ./test.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
 
     - name: Build
       run: ./build.sh
+      env:
+        PACKAGE_ID: ${{secrets.NOT_THERE}}
     - name: Upload bin folder
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    env:
+      VERSION_PREFIX: ${{format('preview-{0}', github.run_number)}}
+ 
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
@@ -20,7 +22,11 @@ jobs:
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Build
-      run: ./build.sh
+      run: dotnet build -c Release --version-suffix ${VERSION_PREFIX}
+    - name: Pack
+      run: dotnet pack -c Release --no-build --version-suffix ${VERSION_PREFIX}
+#      run: ./build.sh
+
     - name: Upload bin folder
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,25 @@ jobs:
       run: dotnet build -c Release
     - name: Pack
       run: dotnet pack -c Release
-    - name: Upload artifact
+    - name: Upload bin folder
       uses: actions/upload-artifact@v1
       with:
         name: bin
         path: IO.Eventuate.Tram/bin
     - name: Unit Tests
-      run: dotnet test -c Release --no-build --verbosity normal IO.Eventuate.Tram.UnitTests/
+      run: dotnet test -c Release --no-build --verbosity normal --logger trx IO.Eventuate.Tram.UnitTests/
+    - name: Upload unit test results
+      uses: actions/upload-artifact@v1
+      with:
+        name: unit-test-results
+        path: IO.Eventuate.Tram.UnitTests/TestResults
     - name: Integration Tests
       run: ./test.sh
       working-directory: ./IO.Eventuate.Tram.IntegrationTests
       env:
         CDC_SERVICE_DOCKER_VERSION: 0.21.3.RELEASE
+    - name: Upload integration test results
+      uses: actions/upload-artifact@v1
+      with:
+        name: integration-test-results
+        path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,7 @@ jobs:
       with:
         dotnet-version: 3.1.101
     - name: Build
-      run: dotnet build -c Release
-    - name: Pack
-      run: dotnet pack -c Release
+      run: ./build.sh
     - name: Upload bin folder
       uses: actions/upload-artifact@v1
       with:
@@ -29,6 +27,7 @@ jobs:
       run: dotnet test -c Release --no-build --verbosity normal --logger trx IO.Eventuate.Tram.UnitTests/
     - name: Upload unit test results
       uses: actions/upload-artifact@v1
+      if: always()
       with:
         name: unit-test-results
         path: IO.Eventuate.Tram.UnitTests/TestResults
@@ -39,6 +38,7 @@ jobs:
         CDC_SERVICE_DOCKER_VERSION: 0.21.3.RELEASE
     - name: Upload integration test results
       uses: actions/upload-artifact@v1
+      if: always()
       with:
         name: integration-test-results
         path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
-        source-url: https://nuget.pkg.github.com/ge-digital-firestorm/index.json
-      env:
-        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     - name: Build
       run: ./build.sh
@@ -53,5 +50,5 @@ jobs:
         name: integration-test-results
         path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults
 
-#    - name: Publish nuget package
-#      run: dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg
+    - name: Publish nuget package
+      run: dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg --source ${{secrets.NUGET_PUBLISH_URL}} --api-key ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Integration Tests
       working-directory: ./IO.Eventuate.Tram.IntegrationTests
       env:
-        CDC_SERVICE_DOCKER_VERSION: 0.21.3.RELEASE
+        CDC_SERVICE_DOCKER_VERSION: 0.6.0.RELEASE
       run: ./test.sh
         
     - name: Upload integration test results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,11 @@ jobs:
         dotnet-version: 3.1.201
 
     - name: Build
-      run: ./build.sh
       env:
+        # Override package name if PACKAGE_ID secret is defined.
+        # If PACKAGE_ID secret is not defined, IO.Eventuate.Tram will be used.
         PACKAGE_ID: ${{secrets.PACKAGE_ID}}
+      run: ./build.sh
         
     - name: Upload bin folder
       uses: actions/upload-artifact@v1
@@ -54,4 +56,6 @@ jobs:
         path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults
 
     - name: Publish nuget package
+      # Don't publish nuget packages for builds triggered by pull requests (pull requests from forks won't have access to secrets anyway)
+      if: github.event_name != 'pull_request'
       run: dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg --source ${{secrets.NUGET_PUBLISH_URL}} --api-key ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: integration-test-results
-        path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults
+        path: ./**/TestResults/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,11 @@ jobs:
       env:
         CDC_SERVICE_DOCKER_VERSION: 0.6.0.RELEASE
       run: ./test.sh
+      
+    - name: Print docker status
+      run: |
+        docker ps
+        docker stats --no-stream --all
         
     - name: Upload integration test results
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build
       run: ./build.sh
       env:
-        PACKAGE_ID: ${{secrets.NOT_THERE}}
+        PACKAGE_ID: ${{secrets.PACKAGE_ID}}
     - name: Upload bin folder
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,4 @@ jobs:
       run: dotnet test -c Release --no-build --verbosity normal IO.Eventuate.Tram.UnitTests/
     - name: Integration Tests
       run: ./test.sh
+      working-directory: ./IO.Eventuate.Tram.IntegrationTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   push:
-    branches: [ * ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
-name: .NET Core
+name: Build
 
 on:
   push:
-    branches: [ master, build ]
+    branches: [ * ]
   pull_request:
     branches: [ master ]
 
@@ -21,5 +21,5 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+    - name: Unit Test
+      run: dotnet test --no-restore --verbosity normal IO.Eventuate.Tram.UnitTests/ 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: integration-test-results
-        path: ./**/TestResults/**
+        path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,5 +45,5 @@ jobs:
       with:
         name: integration-test-results
         path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults
-    - name: Publish nuget package
-      run: dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg
+#    - name: Publish nuget package
+#      run: dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,5 @@ jobs:
     - name: Integration Tests
       run: ./test.sh
       working-directory: ./IO.Eventuate.Tram.IntegrationTests
+      env:
+        CDC_SERVICE_DOCKER_VERSION: 0.21.3.RELEASE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env:
-      VERSION_PREFIX: ${{format('preview-{0}', github.run_number)}}
  
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout source
+      uses: actions/checkout@v2
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
@@ -21,17 +21,15 @@ jobs:
         source-url: https://nuget.pkg.github.com/ge-digital-firestorm/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-    - name: Build
-      run: dotnet build -c Release --version-suffix ${VERSION_PREFIX}
-    - name: Pack
-      run: dotnet pack -c Release --no-build --version-suffix ${VERSION_PREFIX}
-#      run: ./build.sh
 
+    - name: Build
+      run: ./build.sh
     - name: Upload bin folder
       uses: actions/upload-artifact@v1
       with:
         name: bin
         path: IO.Eventuate.Tram/bin
+
     - name: Unit Tests
       run: dotnet test -c Release --no-build --verbosity normal --logger trx IO.Eventuate.Tram.UnitTests/
     - name: Upload unit test results
@@ -40,6 +38,7 @@ jobs:
       with:
         name: unit-test-results
         path: IO.Eventuate.Tram.UnitTests/TestResults
+ 
     - name: Integration Tests
       run: ./test.sh
       working-directory: ./IO.Eventuate.Tram.IntegrationTests
@@ -51,5 +50,6 @@ jobs:
       with:
         name: integration-test-results
         path: IO.Eventuate.Tram.IntegrationTests/bin/Release/netcoreapp3.1/TestResults
+
 #    - name: Publish nuget package
 #      run: dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg

--- a/IO.Eventuate.Tram.IntegrationTests/Dockerfile
+++ b/IO.Eventuate.Tram.IntegrationTests/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 WORKDIR /app
 
 ENTRYPOINT [ "dotnet", "vstest", "IO.Eventuate.Tram.IntegrationTests.dll", "/logger:trx" ]

--- a/IO.Eventuate.Tram.IntegrationTests/Dockerfile
+++ b/IO.Eventuate.Tram.IntegrationTests/Dockerfile
@@ -1,4 +1,0 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
-WORKDIR /app
-
-ENTRYPOINT [ "dotnet", "vstest", "IO.Eventuate.Tram.IntegrationTests.dll", "/logger:trx" ]

--- a/IO.Eventuate.Tram.IntegrationTests/Dockerfile-dbsetup
+++ b/IO.Eventuate.Tram.IntegrationTests/Dockerfile-dbsetup
@@ -1,5 +1,0 @@
-﻿FROM microsoft/mssql-tools:latest
-WORKDIR /scripts
-COPY ./TestDatabase/* ./
-RUN chmod +x ./entrypoint.sh
-CMD ./entrypoint.sh

--- a/IO.Eventuate.Tram.IntegrationTests/IO.Eventuate.Tram.IntegrationTests.csproj
+++ b/IO.Eventuate.Tram.IntegrationTests/IO.Eventuate.Tram.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -23,13 +23,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IO.Eventuate.Tram.IntegrationTests/IO.Eventuate.Tram.IntegrationTests.csproj
+++ b/IO.Eventuate.Tram.IntegrationTests/IO.Eventuate.Tram.IntegrationTests.csproj
@@ -23,11 +23,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>

--- a/IO.Eventuate.Tram.IntegrationTests/TestFixtures/IntegrationTestsBase.cs
+++ b/IO.Eventuate.Tram.IntegrationTests/TestFixtures/IntegrationTestsBase.cs
@@ -28,7 +28,6 @@ namespace IO.Eventuate.Tram.IntegrationTests.TestFixtures
 
         protected TestSettings TestSettings;
 
-        // There can only be one of these between all of the tests because there's no good way to tear it down and start again
         private static IHost _host;
         private static EventuateTramDbContext _dbContext;
         private static IDomainEventPublisher _domainEventPublisher;
@@ -90,7 +89,7 @@ namespace IO.Eventuate.Tram.IntegrationTests.TestFixtures
             catch (DeleteTopicsException e)
             {
                 // Don't fail if topic wasn't found (nothing to delete)
-                if (e.Results.Count == 1 && e.Results[0].Error.Code == ErrorCode.UnknownTopicOrPart)
+                if (e.Results.Where(r => r.Error.IsError).All(r => r.Error.Code == ErrorCode.UnknownTopicOrPart))
                 {
                     TestContext.WriteLine(e.Message);
                 }
@@ -212,8 +211,8 @@ namespace IO.Eventuate.Tram.IntegrationTests.TestFixtures
 
         protected void ClearDb(EventuateTramDbContext dbContext, String eventuateDatabaseSchemaName)
         {
-            dbContext.Database.ExecuteSqlCommand(String.Format("Delete from [{0}].[message]", eventuateDatabaseSchemaName));
-            dbContext.Database.ExecuteSqlCommand(String.Format("Delete from [{0}].[received_messages]", eventuateDatabaseSchemaName));
+            dbContext.Database.ExecuteSqlRaw(String.Format("Delete from [{0}].[message]", eventuateDatabaseSchemaName));
+            dbContext.Database.ExecuteSqlRaw(String.Format("Delete from [{0}].[received_messages]", eventuateDatabaseSchemaName));
         }
     }
 }

--- a/IO.Eventuate.Tram.IntegrationTests/TestFixtures/ProducerConsumerIntegrationTests.cs
+++ b/IO.Eventuate.Tram.IntegrationTests/TestFixtures/ProducerConsumerIntegrationTests.cs
@@ -53,7 +53,7 @@ namespace IO.Eventuate.Tram.IntegrationTests.TestFixtures
 
             GetTestMessageInterceptor()?.AssertCounts(1, 1, 1, 1, 1, 1);
         }
-
+        
         [Test]
         public void Publish_SingleSubscribedMessageType2_MessageReceived()
         {
@@ -315,6 +315,25 @@ namespace IO.Eventuate.Tram.IntegrationTests.TestFixtures
             msg2.AssertGoodMessageReceived(type2Statistics.ReceivedMessages[0]);
             Assert.That(type2Statistics.ReceivedMessages[0].Message.GetHeader(EventMessageHeaders.EventType),
                 Is.EqualTo(TestMessageType2.EventTypeName), "Event type header");
+
+            GetTestMessageInterceptor()?.AssertCounts(1, 1, 1, 1, 1, 1);
+        }
+        
+        [Test]
+        public async Task PublishAsync_SingleSubscribedMessageType1_MessageReceived()
+        {
+            // Arrange
+            TestMessageType1 msg1 = new TestMessageType1("Msg1", 1, 1.2);
+            TestEventConsumer.EventStatistics eventStatistics = GetTestConsumer().GetEventStatistics(
+                typeof(TestMessageType1));
+
+            // Act
+            await GetTestPublisher().PublishAsync(AggregateType12, AggregateType12, new List<IDomainEvent> {msg1});
+
+            // Allow time for messages to process
+            AssertMessagesArePublishedAndConsumed(eventStatistics);
+
+            msg1.AssertGoodMessageReceived(eventStatistics.ReceivedMessages[0]);
 
             GetTestMessageInterceptor()?.AssertCounts(1, 1, 1, 1, 1, 1);
         }

--- a/IO.Eventuate.Tram.IntegrationTests/TestHelpers/DynamicEventuateSchemaModelCacheKeyFactory.cs
+++ b/IO.Eventuate.Tram.IntegrationTests/TestHelpers/DynamicEventuateSchemaModelCacheKeyFactory.cs
@@ -6,7 +6,7 @@ namespace IO.Eventuate.Tram.IntegrationTests.TestHelpers
 {
 	/// <summary>
 	/// Used to ensure a new model is created for each different EventuateSchema
-	/// Otherwise, the first model created is cached and the used even if the EventuateSchema has changed
+	/// Otherwise, the first model created is cached and used even if the EventuateSchema has changed
 	/// </summary>
 	public class DynamicEventuateSchemaModelCacheKeyFactory : IModelCacheKeyFactory
 	{

--- a/IO.Eventuate.Tram.IntegrationTests/TestHelpers/DynamicEventuateSchemaModelCacheKeyFactory.cs
+++ b/IO.Eventuate.Tram.IntegrationTests/TestHelpers/DynamicEventuateSchemaModelCacheKeyFactory.cs
@@ -1,0 +1,22 @@
+using IO.Eventuate.Tram.Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace IO.Eventuate.Tram.IntegrationTests.TestHelpers
+{
+	/// <summary>
+	/// Used to ensure a new model is created for each different EventuateSchema
+	/// Otherwise, the first model created is cached and the used even if the EventuateSchema has changed
+	/// </summary>
+	public class DynamicEventuateSchemaModelCacheKeyFactory : IModelCacheKeyFactory
+	{
+		public object Create(DbContext context)
+		{
+			if (context is EventuateTramDbContext eventuateTramDbContext)
+			{
+				return (context.GetType(), eventuateTramDbContext.EventuateDatabaseSchema);
+			}
+			return context.GetType();
+		}
+	}
+}

--- a/IO.Eventuate.Tram.IntegrationTests/TestHelpers/TestHostBuilder.cs
+++ b/IO.Eventuate.Tram.IntegrationTests/TestHelpers/TestHostBuilder.cs
@@ -4,6 +4,7 @@ using IO.Eventuate.Tram.Events.Subscriber;
 using IO.Eventuate.Tram.Local.Kafka.Consumer;
 using IO.Eventuate.Tram.Messaging.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -65,7 +66,9 @@ namespace IO.Eventuate.Tram.IntegrationTests.TestHelpers
                 {
                     services.AddDbContext<EventuateTramDbContext>((provider, o) =>
                     {
-                        o.UseSqlServer(_sqlConnectionString);
+                        o.UseSqlServer(_sqlConnectionString)
+                            // Use a model cache key factory that ensures a new model is created if EventuateSchema is changed
+                            .ReplaceService<IModelCacheKeyFactory, DynamicEventuateSchemaModelCacheKeyFactory>();
                     });
                     services.AddEventuateTramSqlKafkaTransport(_eventuateDatabaseSchemaName, _kafkaBootstrapServers, EventuateKafkaConsumerConfigurationProperties.Empty(),
                         (provider, o) =>

--- a/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
+++ b/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     volumes:
     - ./bin/Release/netcoreapp3.1:/app
     working_dir: /app
-    entrypoint: [ "dotnet", "test", "IO.Eventuate.Tram.IntegrationTests.dll", "--verbosity", "normal", "--logger", "html", "--logger", "trx" ]
+    entrypoint: [ "dotnet", "test", "IO.Eventuate.Tram.IntegrationTests.dll", "--verbosity", "normal", "--logger", "trx" ]
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
     environment:

--- a/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
+++ b/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
@@ -1,30 +1,34 @@
 version: '3.3'
 services:
   dbsetup:
+    image: microsoft/mssql-tools:latest
     depends_on:
     - mssql
-    build:
-      context: .
-      dockerfile: Dockerfile-dbsetup
     environment:
       TRAM_DB_SERVER: "mssql"
       TRAM_SA_PASSWORD: "TestPa$$word"
       TRAM_DB: "TramDb"
       TRAM_SCHEMA: "eventuate"
       TRAM_SCHEMA2: "schema1"
+    volumes:
+    - ./TestDatabase:/scripts
+    working_dir: /scripts
+    entrypoint: [ "bash", "./entrypoint.sh" ]
   eventuatetramtests:
+    image: mcr.microsoft.com/dotnet/core/sdk:3.1
     depends_on:
     - zookeeper
     - kafka
     - mssql
     - cdcservice1
     - cdcservice2
-    build: .
     environment:
       KafkaBootstrapServers: "kafka:29092"
       ConnectionStrings__EventuateTramDbConnection: "Server=mssql;Database=TramDb;User Id=sa;Password=TestPa$$word"
     volumes:
-    - ./bin/Release/netcoreapp3.1/publish:/app
+    - ./bin/Release/netcoreapp3.1:/app
+    working_dir: /app
+    entrypoint: [ "dotnet", "test", "IO.Eventuate.Tram.IntegrationTests.dll", "--logger", "html", "--logger", "trx" ]
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
     environment:

--- a/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
+++ b/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     volumes:
     - ./bin/Release/netcoreapp3.1:/app
     working_dir: /app
-    entrypoint: [ "dotnet", "test", "IO.Eventuate.Tram.IntegrationTests.dll", "--logger", "html", "--logger", "trx" ]
+    entrypoint: [ "dotnet", "test", "IO.Eventuate.Tram.IntegrationTests.dll", "--verbosity", "normal", "--logger", "html", "--logger", "trx" ]
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
     environment:

--- a/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
+++ b/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       KafkaBootstrapServers: "kafka:29092"
       ConnectionStrings__EventuateTramDbConnection: "Server=mssql;Database=TramDb;User Id=sa;Password=TestPa$$word"
     volumes:
-    - ./bin/Release/netcoreapp2.2/publish:/app
+    - ./bin/Release/netcoreapp3.1/publish:/app
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
     environment:

--- a/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
+++ b/IO.Eventuate.Tram.IntegrationTests/docker-compose.yml
@@ -20,8 +20,7 @@ services:
     - zookeeper
     - kafka
     - mssql
-    - cdcservice1
-    - cdcservice2
+    - cdcservice
     environment:
       KafkaBootstrapServers: "kafka:29092"
       ConnectionStrings__EventuateTramDbConnection: "Server=mssql;Database=TramDb;User Id=sa;Password=TestPa$$word"
@@ -45,60 +44,29 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-  cdcservice1:
-    image: eventuateio/eventuate-tram-cdc-mysql-service:${CDC_SERVICE_DOCKER_VERSION}
+  cdcservice:
+    image: eventuateio/eventuate-cdc-service:${CDC_SERVICE_DOCKER_VERSION}
     depends_on:
     - kafka
     - mssql
     environment:
-      SPRING_DATASOURCE_URL: jdbc:sqlserver://mssql;databaseName=TramDb
-      SPRING_DATASOURCE_USERNAME: sa
-      SPRING_DATASOURCE_PASSWORD: TestPa$$word
-      SPRING_DATASOURCE_TEST_ON_BORROW: "true"
-      SPRING_DATASOURCE_VALIDATION_QUERY: SELECT 1
-      SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.microsoft.sqlserver.jdbc.SQLServerDriver
-
-      SPRING_PROFILES_ACTIVE: EventuatePolling
-
       EVENTUATELOCAL_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       EVENTUATELOCAL_ZOOKEEPER_CONNECTION_STRING: zookeeper:2181
+      
+      EVENTUATE_CDC_READER_READER1_TYPE: polling
+      EVENTUATE_CDC_READER_READER1_DATASOURCEURL: jdbc:sqlserver://mssql;databaseName=TramDb
+      EVENTUATE_CDC_READER_READER1_DATASOURCEUSERNAME: sa
+      EVENTUATE_CDC_READER_READER1_DATASOURCEPASSWORD: TestPa$$word
+      EVENTUATE_CDC_READER_READER1_DATASOURCEDRIVERCLASSNAME: com.microsoft.sqlserver.jdbc.SQLServerDriver
+      EVENTUATE_CDC_READER_READER1_LEADERSHIPLOCKPATH: /eventuatelocal/cdc/leader/1
 
-      EVENTUATE_DATABASE_SCHEMA: eventuate
+      EVENTUATE_CDC_PIPELINE_PIPELINE1_TYPE: eventuate-tram
+      EVENTUATE_CDC_PIPELINE_PIPELINE1_READER: READER1
+      EVENTUATE_CDC_PIPELINE_PIPELINE1_EVENTUATEDATABASESCHEMA: eventuate
 
-      EVENTUATELOCAL_CDC_POLLING_INTERVAL_IN_MILLISECONDS: 500
-      EVENTUATELOCAL_CDC_MAX_EVENTS_PER_POLLING: 1000
-      EVENTUATELOCAL_CDC_MAX_ATTEMPTS_FOR_POLLING: 100
-      EVENTUATELOCAL_CDC_POLLING_RETRY_INTERVAL_IN_MILLISECONDS: 500
-
-      EVENTUATELOCAL_CDC_READER_NAME: Reader1
-      EVENTUATELOCAL_CDC_LEADERSHIP_LOCK_PATH: /eventuatelocal/cdc/leader/1
-  cdcservice2:
-    image: eventuateio/eventuate-tram-cdc-mysql-service:${CDC_SERVICE_DOCKER_VERSION}
-    depends_on:
-    - kafka
-    - mssql
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:sqlserver://mssql;databaseName=TramDb
-      SPRING_DATASOURCE_USERNAME: sa
-      SPRING_DATASOURCE_PASSWORD: TestPa$$word
-      SPRING_DATASOURCE_TEST_ON_BORROW: "true"
-      SPRING_DATASOURCE_VALIDATION_QUERY: SELECT 1
-      SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.microsoft.sqlserver.jdbc.SQLServerDriver
-
-      SPRING_PROFILES_ACTIVE: EventuatePolling
-
-      EVENTUATELOCAL_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
-      EVENTUATELOCAL_ZOOKEEPER_CONNECTION_STRING: zookeeper:2181
-
-      EVENTUATE_DATABASE_SCHEMA: schema1
-
-      EVENTUATELOCAL_CDC_POLLING_INTERVAL_IN_MILLISECONDS: 500
-      EVENTUATELOCAL_CDC_MAX_EVENTS_PER_POLLING: 1000
-      EVENTUATELOCAL_CDC_MAX_ATTEMPTS_FOR_POLLING: 100
-      EVENTUATELOCAL_CDC_POLLING_RETRY_INTERVAL_IN_MILLISECONDS: 500
-
-      EVENTUATELOCAL_CDC_READER_NAME: Reader2
-      EVENTUATELOCAL_CDC_LEADERSHIP_LOCK_PATH: /eventuatelocal/cdc/leader/2
+      EVENTUATE_CDC_PIPELINE_PIPELINE2_TYPE: eventuate-tram
+      EVENTUATE_CDC_PIPELINE_PIPELINE2_READER: READER1
+      EVENTUATE_CDC_PIPELINE_PIPELINE2_EVENTUATEDATABASESCHEMA: schema1
   mssql:
     image: microsoft/mssql-server-linux:2017-latest
     environment:

--- a/IO.Eventuate.Tram.IntegrationTests/test.sh
+++ b/IO.Eventuate.Tram.IntegrationTests/test.sh
@@ -18,5 +18,5 @@ docker-compose up -d cdcservice2
 # Wait for dockers to start up
 sleep 40s
 
-docker-compose run -rm eventuatetramtests
+docker-compose run --rm eventuatetramtests
 docker stats --no-stream --all

--- a/IO.Eventuate.Tram.IntegrationTests/test.sh
+++ b/IO.Eventuate.Tram.IntegrationTests/test.sh
@@ -9,13 +9,13 @@ docker-compose up -d mssql
 # Wait for MSSQL to start up
 sleep 40s
 
-docker-compose up --exit-code-from dbsetup dbsetup
+docker-compose run --rm dbsetup
 docker-compose up -d zookeeper
 docker-compose up -d kafka
 docker-compose up -d cdcservice1
 docker-compose up -d cdcservice2
                             
-# Wait for dockers to start up
+# Wait for docker containers to start up
 sleep 40s
 
 docker-compose run --rm eventuatetramtests

--- a/IO.Eventuate.Tram.IntegrationTests/test.sh
+++ b/IO.Eventuate.Tram.IntegrationTests/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+docker-compose down
+docker-compose up -d mssql
+
+# Wait for MSSQL to start up
+sleep 40s
+
+docker-compose up --exit-code-from dbsetup dbsetup
+docker-compose up -d zookeeper
+docker-compose up -d kafka
+docker-compose up -d cdcservice1
+docker-compose up -d cdcservice2
+                            
+# Wait for dockers to start up
+sleep 40s
+
+docker-compose up --exit-code-from eventuatetramtests eventuatetramtests
+docker stats --no-stream --all

--- a/IO.Eventuate.Tram.IntegrationTests/test.sh
+++ b/IO.Eventuate.Tram.IntegrationTests/test.sh
@@ -12,8 +12,7 @@ sleep 40s
 docker-compose run --rm dbsetup
 docker-compose up -d zookeeper
 docker-compose up -d kafka
-docker-compose up -d cdcservice1
-docker-compose up -d cdcservice2
+docker-compose up -d cdcservice
                             
 # Wait for docker containers to start up
 sleep 40s

--- a/IO.Eventuate.Tram.IntegrationTests/test.sh
+++ b/IO.Eventuate.Tram.IntegrationTests/test.sh
@@ -17,5 +17,9 @@ docker-compose up -d cdcservice
 # Wait for docker containers to start up
 sleep 40s
 
-docker-compose run --rm eventuatetramtests
+# Print docker status
+docker ps
 docker stats --no-stream --all
+
+# Run tests
+docker-compose run --rm eventuatetramtests

--- a/IO.Eventuate.Tram.IntegrationTests/test.sh
+++ b/IO.Eventuate.Tram.IntegrationTests/test.sh
@@ -18,5 +18,5 @@ docker-compose up -d cdcservice2
 # Wait for dockers to start up
 sleep 40s
 
-docker-compose up --exit-code-from eventuatetramtests eventuatetramtests
+docker-compose run -rm eventuatetramtests
 docker stats --no-stream --all

--- a/IO.Eventuate.Tram.UnitTests/Consumer/Database/SqlTableBasedDuplicateMessageDetectorTests.cs
+++ b/IO.Eventuate.Tram.UnitTests/Consumer/Database/SqlTableBasedDuplicateMessageDetectorTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Reflection;
 using IO.Eventuate.Tram.Consumer.Database;
 using IO.Eventuate.Tram.Database;

--- a/IO.Eventuate.Tram.UnitTests/Events/Subscriber/DomainEventDispatcherTests.cs
+++ b/IO.Eventuate.Tram.UnitTests/Events/Subscriber/DomainEventDispatcherTests.cs
@@ -14,7 +14,7 @@ namespace IO.Eventuate.Tram.UnitTests.Events.Subscriber
 {
     public class DomainEventDispatcherTests
     {
-        private String _subscriberId;
+        private String _subscriberId = "test-subscriber-id";
         private static String aggregateType = "AggregateType";
 
         private String aggregateId = "xyz";

--- a/IO.Eventuate.Tram.UnitTests/IO.Eventuate.Tram.UnitTests.csproj
+++ b/IO.Eventuate.Tram.UnitTests/IO.Eventuate.Tram.UnitTests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="NSubstitute" Version="4.0.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IO.Eventuate.Tram.UnitTests/IO.Eventuate.Tram.UnitTests.csproj
+++ b/IO.Eventuate.Tram.UnitTests/IO.Eventuate.Tram.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />

--- a/IO.Eventuate.Tram.sln
+++ b/IO.Eventuate.Tram.sln
@@ -6,6 +6,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2ABE527D-03E2-4126-8392-6ABAEC94EEF8}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
+		.github\workflows\build.yml = .github\workflows\build.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Eventuate.Tram.UnitTests", "IO.Eventuate.Tram.UnitTests\IO.Eventuate.Tram.UnitTests.csproj", "{E64ED890-5DE8-49B1-9585-A48EC1AB8337}"

--- a/IO.Eventuate.Tram.sln
+++ b/IO.Eventuate.Tram.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 		.github\workflows\build.yml = .github\workflows\build.yml
+		build.sh = build.sh
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Eventuate.Tram.UnitTests", "IO.Eventuate.Tram.UnitTests\IO.Eventuate.Tram.UnitTests.csproj", "{E64ED890-5DE8-49B1-9585-A48EC1AB8337}"

--- a/IO.Eventuate.Tram.sln
+++ b/IO.Eventuate.Tram.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 		.github\workflows\build.yml = .github\workflows\build.yml
 		build.sh = build.sh
+		publish-artifacts.sh = publish-artifacts.sh
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Eventuate.Tram.UnitTests", "IO.Eventuate.Tram.UnitTests\IO.Eventuate.Tram.UnitTests.csproj", "{E64ED890-5DE8-49B1-9585-A48EC1AB8337}"

--- a/IO.Eventuate.Tram/Consumer/Database/SqlTableBasedDuplicateMessageDetector.cs
+++ b/IO.Eventuate.Tram/Consumer/Database/SqlTableBasedDuplicateMessageDetector.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Transactions;
 using IO.Eventuate.Tram.Consumer.Common;
 using IO.Eventuate.Tram.Database;

--- a/IO.Eventuate.Tram/Consumer/Kafka/KafkaMessageConsumer.cs
+++ b/IO.Eventuate.Tram/Consumer/Kafka/KafkaMessageConsumer.cs
@@ -131,7 +131,7 @@ namespace IO.Eventuate.Tram.Consumer.Kafka
 		
 		private IMessage ToMessage(ConsumeResult<string, string> record)
 		{
-			return JsonMapper.FromJson<Message>(record.Value);
+			return JsonMapper.FromJson<Message>(record.Message.Value);
 		}
 
 		public void Dispose()

--- a/IO.Eventuate.Tram/Database/EventuateTramDbContext.cs
+++ b/IO.Eventuate.Tram/Database/EventuateTramDbContext.cs
@@ -15,6 +15,8 @@ namespace IO.Eventuate.Tram.Database
 		
 		private readonly EventuateSchema _eventuateSchema;
 
+		public string EventuateDatabaseSchema => _eventuateSchema.EventuateDatabaseSchema;
+
 		/// <summary>
 		/// Default constructor
 		/// </summary>

--- a/IO.Eventuate.Tram/Events/Publisher/IDomainEventPublisher.cs
+++ b/IO.Eventuate.Tram/Events/Publisher/IDomainEventPublisher.cs
@@ -6,6 +6,7 @@
  */
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using IO.Eventuate.Tram.Events.Common;
 
 namespace IO.Eventuate.Tram.Events.Publisher
@@ -15,5 +16,7 @@ namespace IO.Eventuate.Tram.Events.Publisher
 		void Publish(string aggregateType, object aggregateId, IList<IDomainEvent> domainEvents);
 		void Publish(string aggregateType, object aggregateId, IDictionary<string, string> headers, IList<IDomainEvent> domainEvents);
 		void Publish<TAggregate>(object aggregateId, IList<IDomainEvent> domainEvents);
-	}
+		Task PublishAsync(string aggregateType, object aggregateId, IList<IDomainEvent> domainEvents);
+		Task PublishAsync(string aggregateType, object aggregateId, IDictionary<string, string> headers, IList<IDomainEvent> domainEvents);
+		Task PublishAsync<TAggregate>(object aggregateId, IList<IDomainEvent> domainEvents);	}
 }

--- a/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
+++ b/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <VersionSuffix>local</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
+++ b/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <VersionPrefix>0.2.1</VersionPrefix>
     <VersionSuffix>local</VersionSuffix>
-    <RepositoryUrl>https://github.com/ge-digital-firestorm/eventuate-tram-core-dotnet</RepositoryUrl>
+    <RepositoryUrl>https://github.com/eventuate-tram/eventuate-tram-core-dotnet</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
+++ b/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <VersionPrefix>0.2.1</VersionPrefix>
-    <VersionSuffix>local</VersionSuffix>
     <RepositoryUrl>https://github.com/eventuate-tram/eventuate-tram-core-dotnet</RepositoryUrl>
   </PropertyGroup>
 

--- a/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
+++ b/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <VersionPrefix>0.2.1</VersionPrefix>
     <VersionSuffix>local</VersionSuffix>
+    <RepositoryUrl>https://github.com/ge-digital-firestorm/eventuate-tram-core-dotnet</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
+++ b/IO.Eventuate.Tram/IO.Eventuate.Tram.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <RepositoryUrl>https://github.com/eventuate-tram/eventuate-tram-core-dotnet</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/IO.Eventuate.Tram/Local/Kafka/Consumer/EventuateKafkaConsumer.cs
+++ b/IO.Eventuate.Tram/Local/Kafka/Consumer/EventuateKafkaConsumer.cs
@@ -133,7 +133,7 @@ namespace IO.Eventuate.Tram.Local.Kafka.Consumer
 								if (record != null)
 								{
 									_logger.LogDebug(
-										$"{logContext}: process record at offset='{record.Offset}', key='{record.Key}', value='{record.Value}'");
+										$"{logContext}: process record at offset='{record.Offset}', key='{record.Message.Key}', value='{record.Message.Value}'");
 
 									processor.Process(record);
 								}

--- a/IO.Eventuate.Tram/Local/Kafka/Consumer/KafkaMessageProcessor.cs
+++ b/IO.Eventuate.Tram/Local/Kafka/Consumer/KafkaMessageProcessor.cs
@@ -43,7 +43,7 @@ namespace IO.Eventuate.Tram.Local.Kafka.Consumer
 		public void Process(ConsumeResult<string, string> record)
 		{
 			var logContext = $"{nameof(Process)} for {_loggingObjectContext}, " +
-			                 $"record.Key='{record.Key}', record.Topic='{record.Topic}'";
+			                 $"record.Key='{record.Message.Key}', record.Topic='{record.Topic}'";
 			_logger.LogDebug($"+{logContext}");
 			ThrowExceptionIfHandlerFailed();
 			

--- a/IO.Eventuate.Tram/Messaging/Producer/IMessageProducer.cs
+++ b/IO.Eventuate.Tram/Messaging/Producer/IMessageProducer.cs
@@ -5,6 +5,7 @@
  * package:	io.eventuate.tram.messaging.producer
  */
 
+using System.Threading.Tasks;
 using IO.Eventuate.Tram.Messaging.Common;
 
 namespace IO.Eventuate.Tram.Messaging.Producer
@@ -20,5 +21,12 @@ namespace IO.Eventuate.Tram.Messaging.Producer
 		/// <param name="destination">The destination channel</param>
 		/// <param name="message">The message to send</param>
 		void Send(string destination, IMessage message);
+
+		/// <summary>
+		/// Send a message
+		/// </summary>
+		/// <param name="destination">The destination channel</param>
+		/// <param name="message">The message to send</param>
+		Task SendAsync(string destination, IMessage message);
 	}
 }

--- a/IO.Eventuate.Tram/Messaging/Producer/IMessageSender.cs
+++ b/IO.Eventuate.Tram/Messaging/Producer/IMessageSender.cs
@@ -5,6 +5,7 @@
  * package:	io.eventuate.tram.messaging.producer
  */
 
+using System.Threading.Tasks;
 using IO.Eventuate.Tram.Messaging.Common;
 
 namespace IO.Eventuate.Tram.Messaging.Producer
@@ -12,5 +13,7 @@ namespace IO.Eventuate.Tram.Messaging.Producer
 	public interface IMessageSender
 	{
 		void Send(IMessage message);
+
+		Task SendAsync(IMessage message);
 	}
 }

--- a/README.md
+++ b/README.md
@@ -88,33 +88,11 @@ strategy.Execute(() =>
 });
 ```
 
-Finally, the Eventuate Tram CDC service will need to be running and monitoring your database
-for new events to publish. This is easiest to do by running it in a docker container. See below
-for an example docker-compose.yml file:
-```yaml
-version: '3.3'
-services:
-  cdcservice:
-    image: eventuateio/eventuate-tram-cdc-mysql-service:0.21.2
-    ports:
-      - "8099:8080"
-    environment:
-      SPRING_DATASOURCE_URL: <JDBC connection string for database>
-      SPRING_DATASOURCE_USERNAME: <username>
-      SPRING_DATASOURCE_PASSWORD: <password>
-      SPRING_DATASOURCE_TEST_ON_BORROW: "true"
-      SPRING_DATASOURCE_VALIDATION_QUERY: SELECT 1
-      SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.microsoft.sqlserver.jdbc.SQLServerDriver
-      EVENTUATELOCAL_CDC_POLLING_INTERVAL_IN_MILLISECONDS: 500
-      EVENTUATELOCAL_CDC_MAX_EVENTS_PER_POLLING: 1000
-      EVENTUATELOCAL_CDC_MAX_ATTEMPTS_FOR_POLLING: 100
-      EVENTUATELOCAL_CDC_POLLING_RETRY_INTERVAL_IN_MILLISECONDS: 500
-      EVENTUATELOCAL_KAFKA_BOOTSTRAP_SERVERS: <bootstrapServers>
-      EVENTUATELOCAL_ZOOKEEPER_CONNECTION_STRING: <zookeeper host:port>
-      EVENTUATE_DATABASE_SCHEMA: <DB schema name>
-      SPRING_PROFILES_ACTIVE: EventuatePolling
-      EVENTUATELOCAL_CDC_READER_NAME: <Reader name>
-```
+Finally, the [Eventuate CDC Service](https://github.com/eventuate-foundation/eventuate-cdc) will need to be running and monitoring your database
+for new events to publish. The [Eventuate Tram Code Basic examples](https://github.com/eventuate-tram/eventuate-tram-core-examples-basic) 
+project has an example docker-compose.yml file. See also the Eventuate CDC Service configuration 
+[documentation](https://eventuate.io/docs/manual/eventuate-tram/latest/cdc-configuration.html).
+
 ### Consuming Events (Option 1)
 
 Create one or more event handler services that implements IDomainEventHandler<TEvent>. You could have 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ using (var scope = new TransactionScope())
     scope.Complete();
 }
 ```
+Alternatively, there is also an asynchronous publish method available:
+```c#
+using (var scope = new TransactionScope(new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled)))
+{
+    await _applicationDbContext.SaveChangesAsync();
+    await _domainEventPublisher.PublishAsync(aggregateType, aggregateId, new List<IDomainEvent> {@event});
+    scope.Complete();
+}
+```
 
 If EnableRetryOnFailure is enabled on your DbContext, you will need to wrap the transaction in
 an ExecutionStrategy Execute() method:

--- a/README.md
+++ b/README.md
@@ -241,20 +241,12 @@ You can use the following steps to run the tests:
 
 ```
 $ cd IO.Eventuate.Tram.IntegrationTests
-$ dotnet publish -c Release
+$ dotnet build -c Release
 $ export CDC_SERVICE_DOCKER_VERSION=<CDC docker tag>
-$ docker-compose down
-$ docker-compose build
-$ docker-compose up -d mssql
-$ docker-compose up --exit-code-from dbsetup dbsetup
-$ docker-compose up -d zookeeper
-$ docker-compose up -d kafka
-$ docker-compose up -d cdcservice1
-$ docker-compose up -d cdcservice2
-$ docker-compose up eventuatetramtests
+$ ./test.sh
 ```
 
-Test results will be written to ./bin/Release/netcoreapp2.2/publish/TestResults.
+Test results will be written to ./bin/Release/netcoreapp3.1/TestResults.
 
 ### Environment Variable Configuration
 

--- a/build.sh
+++ b/build.sh
@@ -3,14 +3,14 @@
 set -e
 set -x
 
-# Always a preview version for now
-IS_PREVIEW=true
-
-VERSION_PREFIX='""'
-if [[ ${IS_PREVIEW} = true ]] ; then
+VERSION_ARGS=()
+# If this is not a tagged release, set version suffix to 'preview-{run_number}'
+# Otherwise we will use the version as it is defined in the project file
+if [[ ${IS_TAGGED_RELEASE} != 'true' ]] ; then
     VERSION_SUFFIX=preview-${GITHUB_RUN_NUMBER:-local}
+    VERSION_ARGS=("--version-suffix" "${VERSION_SUFFIX}")
 fi
 
-dotnet build -c Release --version-suffix ${VERSION_SUFFIX}
+dotnet build -c Release ${VERSION_ARGS[@]}
 
-dotnet pack -c Release --no-build --version-suffix ${VERSION_SUFFIX} -p:PackageId=${PACKAGE_ID:-IO.Eventuate.Tram} IO.Eventuate.Tram
+dotnet pack -c Release --no-build ${VERSION_ARGS[@]} -p:PackageId=${PACKAGE_ID:-IO.Eventuate.Tram} IO.Eventuate.Tram

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+# Always a preview version for now
+IS_PREVIEW=true
+
+VERSION_PREFIX='""'
+if [[ ${IS_PREVIEW} = true ]] ; then
+    VERSION_PREFIX=preview-${GITHUB_RUN_NUMBER}
+fi
+
+dotnet build -c Release --version-suffix ${VERSION_PREFIX}
+
+dotnet pack -c Release --version-suffix ${VERSION_PREFIX}

--- a/build.sh
+++ b/build.sh
@@ -8,11 +8,11 @@ IS_PREVIEW=true
 
 VERSION_PREFIX='""'
 if [[ ${IS_PREVIEW} = true ]] ; then
-    VERSION_PREFIX=preview-${GITHUB_RUN_NUMBER}
+    VERSION_PREFIX=preview-${GITHUB_RUN_NUMBER:-local}
 fi
 
-PROPS="-p:PackageId=${PACKAGE_ID} -p:RepositoryUrl=https://github.com/${GITHUB_REPOSITORY}"
+PROPS="-p:RepositoryUrl=https://github.com/${GITHUB_REPOSITORY}"
 
 dotnet build -c Release --version-suffix ${VERSION_PREFIX} ${PROPS}
 
-dotnet pack -c Release --no-build --version-suffix ${VERSION_PREFIX} ${PROPS} IO.Eventuate.Tram
+dotnet pack -c Release --no-build --version-suffix ${VERSION_PREFIX} -p:PackageId=${PACKAGE_ID:-IO.Eventuate.Tram} ${PROPS} IO.Eventuate.Tram

--- a/build.sh
+++ b/build.sh
@@ -8,11 +8,9 @@ IS_PREVIEW=true
 
 VERSION_PREFIX='""'
 if [[ ${IS_PREVIEW} = true ]] ; then
-    VERSION_PREFIX=preview-${GITHUB_RUN_NUMBER:-local}
+    VERSION_SUFFIX=preview-${GITHUB_RUN_NUMBER:-local}
 fi
 
-PROPS="-p:RepositoryUrl=https://github.com/${GITHUB_REPOSITORY}"
+dotnet build -c Release --version-suffix ${VERSION_SUFFIX}
 
-dotnet build -c Release --version-suffix ${VERSION_PREFIX} ${PROPS}
-
-dotnet pack -c Release --no-build --version-suffix ${VERSION_PREFIX} -p:PackageId=${PACKAGE_ID:-IO.Eventuate.Tram} ${PROPS} IO.Eventuate.Tram
+dotnet pack -c Release --no-build --version-suffix ${VERSION_SUFFIX} -p:PackageId=${PACKAGE_ID:-IO.Eventuate.Tram} IO.Eventuate.Tram

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,8 @@ if [[ ${IS_PREVIEW} = true ]] ; then
     VERSION_PREFIX=preview-${GITHUB_RUN_NUMBER}
 fi
 
-dotnet build -c Release --version-suffix ${VERSION_PREFIX}
+PROPS="-p:PackageId=${PACKAGE_ID} -p:RepositoryUrl=https://github.com/${GITHUB_REPOSITORY}"
 
-dotnet pack -c Release --version-suffix ${VERSION_PREFIX}
+dotnet build -c Release --version-suffix ${VERSION_PREFIX} ${PROPS}
+
+dotnet pack -c Release --no-build --version-suffix ${VERSION_PREFIX} ${PROPS} IO.Eventuate.Tram

--- a/publish-artifacts.sh
+++ b/publish-artifacts.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ ${IS_TAGGED_RELEASE} = 'true' ]] ; then
+    echo Publishing tagged release nuget package
+    dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg --source ${NUGET_PUBLISH_URL} --api-key ${NUGET_API_KEY}
+else
+    echo Publishing snapshot nuget package
+    dotnet nuget push IO.Eventuate.Tram/bin/Release/*.nupkg --source ${SNAPSHOT_NUGET_PUBLISH_URL} --api-key ${SNAPSHOT_NUGET_API_KEY}
+fi


### PR DESCRIPTION
Adds a CI build using a GitHub Actions work flow.

Expects Actions to be enabled on the GitHub repository and the following secrets to be defined:
SNAPSHOT_NUGET_PUBLISH_URL
SNAPSHOT_NUGET_API_KEY
NUGET_PUBLISH_URL
NUGET_API_KEY

Builds are triggered on a push to any branch or a pull request to master. A build is considered a "release build" if it is triggered by a pushed tag that starts with "v" (e.g. "v0.3.0"), otherwise it is considered a "snapshot build". Snapshot builds have a version suffix set to "preview-{build_run_number}" (the version prefix is defined in the project file). Release builds use the version (prefix and suffix) as it is defined in the project file (csproj). Snapshot and release builds publish a nuget package to different repositories, configured by secrets.

There is also an "optional" PACKAGE_ID secret that can be defined to override the nuget package name. If the secret is not configured, it will use the default value of IO.Eventuate.Tram.

Note: This build contains the changes from https://github.com/eventuate-tram/eventuate-tram-core-dotnet/pull/4, so it might make sense to merge that one first.