### PR TITLE
Support overriding the MAC address used for message ID generation

### DIFF
--- a/IO.Eventuate.Tram.UnitTests/IdGeneratorTests.cs
+++ b/IO.Eventuate.Tram.UnitTests/IdGeneratorTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -6,17 +7,23 @@ namespace IO.Eventuate.Tram.UnitTests
 {
 	public class IdGeneratorTests
 	{
-		private IdGenerator _generator;
 		private ITimingProvider _timingProvider;
+		private IOptions<IdGeneratorOptions> _idGeneratorOptions;
+		private ILogger<IdGenerator> _logger;
 		private bool _wasDelayed;
 		private long _nowMilliseconds;
 
 		[SetUp]
-		public void SetupIdGenerator()
+		public void SetupIdGeneratorDependencies()
 		{
-			var logger = Substitute.For<ILogger<IdGenerator>>();
+			_logger = Substitute.For<ILogger<IdGenerator>>();
 			_timingProvider = Substitute.For<ITimingProvider>();
-			_generator = new IdGenerator(_timingProvider, logger);
+			_idGeneratorOptions = Substitute.For<IOptions<IdGeneratorOptions>>();
+		}
+
+		private IdGenerator CreateIdGenerator()
+		{
+			return new IdGenerator(_timingProvider, _idGeneratorOptions, _logger);
 		}
 
 		[TestCase(1)]
@@ -29,12 +36,13 @@ namespace IO.Eventuate.Tram.UnitTests
 				.Do(arg => _wasDelayed = true);
 			_timingProvider.GetNowMilliseconds()
 				.ReturnsForAnyArgs(x => _wasDelayed ? ++_nowMilliseconds : _nowMilliseconds);
+			IdGenerator generator = CreateIdGenerator();
 
 			// Act
 			Int128 id = null;
 			for (int i = 0; i < numberOfIds; i++)
 			{
-				id = _generator.GenId();
+				id = generator.GenId();
 			}
 
 			// Assert
@@ -51,18 +59,35 @@ namespace IO.Eventuate.Tram.UnitTests
 				.Do(arg => _wasDelayed = true);
 			_timingProvider.GetNowMilliseconds()
 				.ReturnsForAnyArgs(x => _wasDelayed ? ++_nowMilliseconds : _nowMilliseconds);
+			IdGenerator generator = CreateIdGenerator();
 
 			// Act
 			int numberOfIds = 0x10001;
 			Int128 id = null;
 			for (int i = 0; i < numberOfIds; i++)
 			{
-				id = _generator.GenId();
+				id = generator.GenId();
 			}
 
 			// Assert
 			_timingProvider.Received(1).DelayMilliseconds(Arg.Any<int>());
 			Assert.That(id?.Lo & 0xffff, Is.EqualTo(0), "Count part of ID");
+		}
+		
+		[Test]
+		public void GetId_MacAddressOverridden_IdUsesOverriddenMacAddress()
+		{
+			// Arrange
+			const string macAddressOverride = "12345";
+			const long expectedMacAddress = 12345L;
+			_idGeneratorOptions.Value.Returns(new IdGeneratorOptions {MacAddress = macAddressOverride});
+			IdGenerator generator = CreateIdGenerator();
+
+			// Act
+			Int128 id = generator.GenId();
+
+			// Assert
+			Assert.That(id?.Lo >> 16, Is.EqualTo(expectedMacAddress), "MAC address part of ID");
 		}
 	}
 }

--- a/IO.Eventuate.Tram.UnitTests/IdGeneratorTests.cs
+++ b/IO.Eventuate.Tram.UnitTests/IdGeneratorTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NUnit.Framework;
@@ -88,6 +89,18 @@ namespace IO.Eventuate.Tram.UnitTests
 
 			// Assert
 			Assert.That(id?.Lo >> 16, Is.EqualTo(expectedMacAddress), "MAC address part of ID");
+		}
+
+		[Test]
+		public void Constructor_MacAddressOverriddenWithInvalidValue_ThrowsFormatException()
+		{
+			// Arrange
+			const string macAddressOverride = "BigMac";
+			const long expectedMacAddress = 12345L;
+			_idGeneratorOptions.Value.Returns(new IdGeneratorOptions {MacAddress = macAddressOverride});
+
+			// Act / Assert
+			Assert.Throws<FormatException>(() => new IdGenerator(_timingProvider, _idGeneratorOptions, _logger));
 		}
 	}
 }

--- a/IO.Eventuate.Tram.UnitTests/IdGeneratorTests.cs
+++ b/IO.Eventuate.Tram.UnitTests/IdGeneratorTests.cs
@@ -96,7 +96,6 @@ namespace IO.Eventuate.Tram.UnitTests
 		{
 			// Arrange
 			const string macAddressOverride = "BigMac";
-			const long expectedMacAddress = 12345L;
 			_idGeneratorOptions.Value.Returns(new IdGeneratorOptions {MacAddress = macAddressOverride});
 
 			// Act / Assert

--- a/IO.Eventuate.Tram/IdGenerator.cs
+++ b/IO.Eventuate.Tram/IdGenerator.cs
@@ -33,12 +33,13 @@ namespace IO.Eventuate.Tram
 
 		private long _currentPeriod;
 		private long _counter;
-		
+
 		/// <summary>
 		/// Construct the ID generator. Reads the MAC address of the first NIC.
 		/// </summary>
 		/// <param name="timingProvider">Interface for getting the current time and delaying the generator
 		/// while waiting for a new time</param>
+		/// <param name="idGeneratorOptions">IdGenerator configuration options</param>
 		/// <param name="logger">Logger</param>
 		public IdGenerator(ITimingProvider timingProvider, IOptions<IdGeneratorOptions> idGeneratorOptions, ILogger<IdGenerator> logger)
 		{

--- a/IO.Eventuate.Tram/IdGeneratorOptions.cs
+++ b/IO.Eventuate.Tram/IdGeneratorOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace IO.Eventuate.Tram
+{
+	public class IdGeneratorOptions
+	{
+		public string MacAddress { get; set; }
+	}
+}

--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ for new events to publish. The [Eventuate Tram Code Basic examples](https://gith
 project has an example docker-compose.yml file. See also the Eventuate CDC Service configuration 
 [documentation](https://eventuate.io/docs/manual/eventuate-tram/latest/cdc-configuration.html).
 
+#### Message ID Generation
+
+Eventuate Tram generates message IDs using the network interface's MAC address by default when publishing messages. 
+This can result in duplicate message IDs being generated if multiple processes using Eventuate Tram 
+are running on the same machine. To avoid this, the MAC address used for the purpose of ID generation 
+can be overridden by setting the IdGeneratorOptions in Startup.cs. For example, the MAC address can 
+be set from a configuration property value:
+```c#
+services.Configure<IdGeneratorOptions>(o =>
+{
+    o.MacAddress = _configuration.GetValue<string>("EventuateMacAddress");
+});
+
+```
+This would allow overriding the MAC address via configuration (e.g. by setting the 
+`EventuateMacAddress` property within the appsettings.json file or via an environment variable).
+
+Note that the specified "MAC address" should be a number specified as a base 10 integer value with a 
+maximum of 140737488355327.
+
 ### Consuming Events (Option 1)
 
 Create one or more event handler services that implements IDomainEventHandler<TEvent>. You could have 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,12 @@ strategy.Execute(() =>
 {
     using (var scope = new TransactionScope())
     {
-        _applicationDbContext.SaveChanges();
+        // Defer accepting changes until after transaction is committed so that
+        // the changes are saved again on an execution strategy retry
+        _applicationDbContext.SaveChanges(false);
         _domainEventPublisher.Publish(aggregateType, aggregateId, new List<IDomainEvent> {@event});
         scope.Complete();
+        _applicationDbContext.ChangeTracker.AcceptAllChanges();
     }
 });
 ```


### PR DESCRIPTION
Allows for the the MAC address that is used for message ID generation to be overridden via configuration. This allows multiple processes on the same machine to publish messages without the risk of generating duplicate IDs.